### PR TITLE
Reallow old float options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,18 +136,17 @@ types, so the flag is false by default.
 Enabling this flag may produce huge amount of pre_encode_hook() calls (the
 hook will be called for every single JSON value) and thus affect the performance.
 
+double_precision
+----------------
+
+This option is ignored, and is allowed for compatibility with ujson 1.35
 
 ~~~~~~~~~~~~~~~~
 Decoders options
 ~~~~~~~~~~~~~~~~
 precise_float
 -------------
-Set to enable usage of higher precision (strtod) function when decoding string to double values. Default is to use fast but less precise builtin functionality::
-
-    >>> ujson.loads("4.56")
-    4.5600000000000005
-    >>> ujson.loads("4.56", precise_float=True)
-    4.5599999999999996
+This option is ignored, and is allowed for compatibility with ujson 1.35
 
 object_hook
 -----------

--- a/python/JSONtoObj.c
+++ b/python/JSONtoObj.c
@@ -164,7 +164,7 @@ static void Object_releaseObject(void *prv, JSOBJ obj)
   Py_DECREF( ((PyObject *)obj));
 }
 
-static char *g_kwlist[] = {"obj", "object_hook", "string_hook", NULL};
+static char *g_kwlist[] = {"obj", "object_hook", "string_hook", "precise_float", NULL};
 
 PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
 {
@@ -173,6 +173,7 @@ PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
   PyObject *arg;
   PyObject *oobjectHook = NULL;
   PyObject *ostringHook = NULL;
+  PyObject *opreciseFloat = NULL;
 
   JSONObjectDecoder decoder =
   {
@@ -201,7 +202,7 @@ PyObject* JSONToObj(PyObject* self, PyObject *args, PyObject *kwargs)
   };
   decoder.prv = &dp;
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OO", g_kwlist, &arg, &oobjectHook, &ostringHook))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOO", g_kwlist, &arg, &oobjectHook, &ostringHook, &opreciseFloat))
   {
       return NULL;
   }

--- a/python/objToJSON.c
+++ b/python/objToJSON.c
@@ -790,7 +790,7 @@ static char *Object_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen)
 
 PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 {
-  static char *kwlist[] = { "obj", "ensure_ascii", "encode_html_chars", "escape_forward_slashes", "sort_keys", "indent", "pre_encode_hook", "pre_encode_primitive", NULL };
+  static char *kwlist[] = { "obj", "ensure_ascii", "encode_html_chars", "escape_forward_slashes", "sort_keys", "indent", "pre_encode_hook", "pre_encode_primitive", "double_precision", NULL };
 
   char buffer[65536];
   char *ret;
@@ -802,6 +802,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
   PyObject *osortKeys = NULL;
   PyObject *opreEncodeHook = NULL;
   PyObject *opreEncodePrimitive = NULL;
+  PyObject *odoublePrecision = NULL;
 
   JSONObjectEncoder encoder =
   {
@@ -837,7 +838,7 @@ PyObject* objToJSON(PyObject* self, PyObject *args, PyObject *kwargs)
 
   PRINTMARK();
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOOOiOO", kwlist, &oinput, &oensureAscii, &oencodeHTMLChars, &oescapeForwardSlashes, &osortKeys, &encoder.indent, &opreEncodeHook, &opreEncodePrimitive))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|OOOOiOOO", kwlist, &oinput, &oensureAscii, &oencodeHTMLChars, &oescapeForwardSlashes, &osortKeys, &encoder.indent, &opreEncodeHook, &opreEncodePrimitive, &odoublePrecision))
   {
     return NULL;
   }


### PR DESCRIPTION
I'm not suggesting we keep these forever, but in order to be able to switch back and forth between the latest released version of ujson with reasonable float precision, and ujson-ia which has this by default, would be nice if we can still specify the options for a while.

About six months would be enough to satisfy our migration, at which point they can be removed.