### PR TITLE
Fix potential buffer overflow due to large indents.

### DIFF
--- a/lib/ultrajsonenc.c
+++ b/lib/ultrajsonenc.c
@@ -694,12 +694,14 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
         iterObj = enc->iterGetValue(obj, &tc);
 
         enc->level ++;
+        Buffer_Reserve (enc, enc->indent * enc->level);
         Buffer_AppendIndentUnchecked (enc, enc->level);
         encode (iterObj, enc, NULL, 0);
         count ++;
       }
 
       enc->iterEnd(obj, &tc);
+      Buffer_Reserve (enc, enc->indent * enc->level);
       Buffer_AppendIndentNewlineUnchecked (enc);
       Buffer_AppendIndentUnchecked (enc, enc->level);
       Buffer_AppendCharUnchecked (enc, ']');
@@ -715,6 +717,7 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
 
       while ((res = enc->iterNext(obj, &tc)))
       {
+        Buffer_Reserve (enc, 3 + (enc->indent * (enc->level + 1)));
         if(res < 0)
         {
           enc->iterEnd(obj, &tc);
@@ -742,6 +745,7 @@ static void encode(JSOBJ obj, JSONObjectEncoder *enc, const char *name, size_t c
       }
 
       enc->iterEnd(obj, &tc);
+      Buffer_Reserve (enc, enc->indent * enc->level);
       Buffer_AppendIndentNewlineUnchecked (enc);
       Buffer_AppendIndentUnchecked (enc, enc->level);
       Buffer_AppendCharUnchecked (enc, '}');


### PR DESCRIPTION
Fixes https://github.com/esnme/ultrajson/issues/334

The crash repro is linked from that issue, https://gist.github.com/kangzhang/11b36aaa124bb425536bda1aaebc1a49

I modified it to test all indents from 0 to 99 and they all pass with this.  I'm not a fan of how this append code works in the first place, because it's clearly performance-over-safety, so I'm not 100% sure that my solution is fully correct.  This ought to be fuzzed and have more complex tests written at some point.